### PR TITLE
Adding property name to throw expound error instead of ambiguous reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ var expound, extend, throwExpound = function (msg) {
 								checkConstraint.call(this, checkType.extendsType);
 							}
 							if (!checkType.constraint(this.value)) {
-								throwExpound('Value does not pass type constraint. Expecting: ' + type);
+								throwExpound('Value ' + this.name + ' does not pass type constraint. Expecting: ' + type);
 							}
 							return true;
 						};


### PR DESCRIPTION
Before if a property is incorrectly typed (eg. isArray) it would not tell you what property was incorrect.  So I added a reference to this.name in the message for clarity.
